### PR TITLE
Fix libao compile error on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,13 @@ project(vgmplay VERSION 0.5 LANGUAGES C CXX)
 #set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 #set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/libvgm/libs/cmake_modules/")
+
 find_package(ZLIB REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Iconv QUIET)
 find_package(libvgm REQUIRED)
+find_package(LibAO REQUIRED)
 
 if(MSVC)
 	if(CMAKE_CL_64)


### PR DESCRIPTION
When compiling on Ubuntu 20.04, with all dependent packages installed, I get this libao related compile/link error:
![image](https://user-images.githubusercontent.com/1383530/108398602-0c63c980-71ce-11eb-9d73-bb3656cc44ca.png)

I barely know how to use cmake, but this change fixed it on my machine. There's probably a better way, but I dont know enough about cmake. This change has not been tested in Windows or any other distros.