### PR TITLE
Try to fix MSVC CI

### DIFF
--- a/.github/workflows/GHA.yml
+++ b/.github/workflows/GHA.yml
@@ -56,6 +56,12 @@ jobs:
     - name: Configure
       run: |
         export CMAKE_MODULE_PATH="${GITHUB_WORKSPACE}/libvgm/install/lib/cmake"${CMAKE_MODULE_PATH:+':'}$CMAKE_MODULE_PATH
+
+        # FIXME: This should prolly be addressed in libvgm's action.yml instead
+        if [ "${{ matrix.config.compiler}}" == "msvc" ]; then
+          CMAKE_OPTS="$CMAKE_OPTS -DZLIB_INCLUDE_DIR=${GITHUB_WORKSPACE}/libvgm/libs/include"
+        fi
+
         cmake ${{ matrix.config.extra_settings }} \
           -B ${GITHUB_WORKSPACE}/build \
           -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \


### PR DESCRIPTION
```
CMake Error at C:/Program Files/CMake/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find ZLIB (missing: ZLIB_INCLUDE_DIR)
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  C:/Program Files/CMake/share/cmake-3.31/Modules/FindZLIB.cmake:202 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
  libvgm/build/libvgmConfig.cmake:28 (find_dependency)
  CMakeLists.txt:19 (find_package)
```

The most correct thing would prolly be to:

1. Move the CMake code in libvgm that makes MSVC builds use the prebuilt vendored libraries & headers (https://github.com/ValleyBell/libvgm/blob/57585ea7a53f56bcf5a56071068c6ef9154ca299/CMakeLists.txt#L56-L72) from the CMake code into documented configure-time flags for easy testing.
2. Work these flags into the GHA code (https://github.com/ValleyBell/libvgm/blob/57585ea7a53f56bcf5a56071068c6ef9154ca299/.github/workflows/action-build-libvgm/action.yml#L54-L64) so the libvgm CI build still has them.
3. Update the libvgm module here so the vgmplay-libvgm build can reuse the same convenience flags without manually duplicating & syncing code.

…but it should be quicker to just append this (and maybe some other flags) for now.