### PR TITLE
add support for per-instance chip control in config

### DIFF
--- a/VGMPlay.ini
+++ b/VGMPlay.ini
@@ -127,6 +127,11 @@ ShowStreamCmds = 3
 ;	mute channel ?
 ; - Mutexxx = False/True
 ;	mute channel with the name xxx (e.g. DAC, DT, BD, ...)
+; - [K054539#0]
+;   MuteCh? = True
+;   [K054539#1]
+;   Disabled = True
+;   disable or mute channel ? on a specific chip if two chips of the same kind appear in a VGM rip
 ; - PanMask = 0,0,0,...
 ;	set panning position for all channels, one value per channel, separated by commas
 ;	Range: -1.0 = left ... 0.0 = centre ... +1.0 = right

--- a/mediainfo.hpp
+++ b/mediainfo.hpp
@@ -82,7 +82,7 @@ public:
 	
 	volatile UINT8 _playState;
 	GeneralOptions _genOpts;
-	ChipOptions _chipOpts[0x100];
+	ChipOptions _chipOpts[0x300];
 	PlayerA _player;
 	
 	std::string _fileFmt;

--- a/playcfg.cpp
+++ b/playcfg.cpp
@@ -149,6 +149,27 @@ void ParseConfiguration(GeneralOptions& gOpts, size_t cOptCnt, ChipOptions* cOpt
 			ParseCfg_ChipSection(cOpts[cfgChip.chipType], sectIt->second, cfgChip.chipType);
 		else
 			ParseCfg_ChipSection(cOpts[cfgChip.chipType], dummySect, cfgChip.chipType);
+		// per-instance chip control: [Chip#N] or [Chip-N] where N is 0 or 1
+		for (UINT8 inst = 0; inst < 2; inst ++)
+		{
+			char iSect[32]; char suf[4];
+			sectIt = cfg._sections.end();
+			suf[0] = '#'; suf[1] = '0' + inst; suf[2] = 0;
+			strcpy(iSect, cfgChip.entryName); strcat(iSect, suf);
+			sectIt = cfg._sections.find(iSect);
+			if (sectIt == cfg._sections.end())
+			{
+				suf[0] = '-';
+				strcpy(iSect, cfgChip.entryName); strcat(iSect, suf);
+				sectIt = cfg._sections.find(iSect);
+			}
+			if (sectIt != cfg._sections.end())
+			{
+				size_t slot = 0x100 + ((size_t)cfgChip.chipType << 1) + inst;
+				ParseCfg_ChipSection(cOpts[slot], sectIt->second, cfgChip.chipType);
+				cOpts[slot].chipInstance = inst;
+			}
+		}
 	}
 	
 	return;

--- a/playctrl.cpp
+++ b/playctrl.cpp
@@ -173,7 +173,7 @@ UINT8 PlayerMain(UINT8 showFileName)
 	else
 		fnShowMode = 0;
 	
-	ParseConfiguration(genOpts, 0x100, mediaInfo._chipOpts, playerCfg);
+	ParseConfiguration(genOpts, 0x300, mediaInfo._chipOpts, playerCfg);
 	
 	{
 		// Manual initialization of adOut/adLog, because MSVC6 is unable to
@@ -220,7 +220,7 @@ UINT8 PlayerMain(UINT8 showFileName)
 	myPlayer.SetFileReqCallback(PlayerFileReqCallback, NULL);
 	myPlayer.SetLogCallback(PlayerLogCallback, NULL);
 	ApplyCfg_General(myPlayer, genOpts);
-	for (size_t curChp = 0; curChp < 0x100; curChp ++)
+	for (size_t curChp = 0; curChp < 0x300; curChp ++)
 	{
 		const ChipOptions& cOpt = mediaInfo._chipOpts[curChp];
 		if (cOpt.chipType == 0xFF)


### PR DESCRIPTION
Sometimes there may be more than one K054539, more than one YM2203, or some other combination of sound chips, but prior to this commit, muting a channel or disabling a sound chip applied to both sound chips.

Now it's possible to mute/isolate channel X on just one of two sound chips, instead of having channel X get muted on both sound chips all the time